### PR TITLE
Potential fix for code scanning alert no. 1: Incorrect conversion between integer types

### DIFF
--- a/internal/codespaces/portforwarder/port_forwarder.go
+++ b/internal/codespaces/portforwarder/port_forwarder.go
@@ -17,6 +17,14 @@ const (
 	UserForwardedPortLabel = "UserForwardedPort"
 )
 
+// convertIntToUint16 safely converts an int to uint16, returning an error if out of range.
+func convertIntToUint16(port int) (uint16, error) {
+	if port < 0 || port > 65535 {
+		return 0, fmt.Errorf("port number %d out of range (0-65535)", port)
+	}
+	return uint16(port), nil
+}
+
 const (
 	PrivatePortVisibility = "private"
 	OrgPortVisibility     = "org"
@@ -264,7 +272,11 @@ func (fwd *CodespacesPortForwarder) UpdatePortVisibility(ctx context.Context, re
 	}
 
 	// Delete the existing tunnel port to update
-	err = fwd.connection.TunnelManager.DeleteTunnelPort(ctx, fwd.connection.Tunnel, uint16(remotePort), fwd.connection.Options)
+	port16, err := convertIntToUint16(remotePort)
+	if err != nil {
+		return fmt.Errorf("invalid port number: %w", err)
+	}
+	err = fwd.connection.TunnelManager.DeleteTunnelPort(ctx, fwd.connection.Tunnel, port16, fwd.connection.Options)
 	if err != nil {
 		return fmt.Errorf("error deleting tunnel port: %w", err)
 	}


### PR DESCRIPTION
Potential fix for [https://github.com/ReuelAlbert-Dev/cli/security/code-scanning/1](https://github.com/ReuelAlbert-Dev/cli/security/code-scanning/1)

To fix the problem, we need to ensure that any integer value being cast to `uint16` is within the valid range for a port (0-65535). The best way to do this is to add an explicit bounds check before performing the cast. If the value is out of bounds, we should return an error, preventing the operation from proceeding with an invalid port number. The conversion occurs in `internal/codespaces/portforwarder/port_forwarder.go` on line 267, so we should add a helper function to check the bounds and perform the conversion safely. We should also update the call site to use this helper, and handle the error appropriately.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
